### PR TITLE
Fix env var Markdown formatting

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -210,7 +210,7 @@ inputs:
         You can use multiple options, separated by a space
         character. Example: `--stacktrace --debug`
         If `--debug` or `-d` options are set then only the last 20 lines of the raw gradle output will be visible in the build log.
-        The full raw output will be exported to the $BITRISE_GRADLE_RAW_RESULT_TEXT_PATH variable and will be added as an artifact.
+        The full raw output will be exported to the `$BITRISE_GRADLE_RAW_RESULT_TEXT_PATH` variable and will be added as an artifact.
   - retry_on_failure: "yes"
     opts:
       category: Debug


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

Without the backtick code format, the underscores in the env var are interpreted as Markdown _italics_ formatting.

![image](https://user-images.githubusercontent.com/1694986/114357556-b7399980-9b26-11eb-8ab8-f22e22980950.png)
