### PR TITLE
Improve log messages when duplicate files are copied to the outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .bitrise*
 _tmp/
 .gradle
+.idea/

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/bitrise-io/go-android v0.0.0-20210527143215-3ad22ad02e2e
 	github.com/bitrise-io/go-steputils v0.0.0-20210527075147-910ce7a105a1
-	github.com/bitrise-io/go-utils v0.0.0-20210520073355-367fa34178f5
+	github.com/bitrise-io/go-utils v0.0.0-20210713111255-08be784d45d0
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,9 @@ github.com/bitrise-io/go-steputils v0.0.0-20210514150206-5b6261447e77/go.mod h1:
 github.com/bitrise-io/go-steputils v0.0.0-20210527075147-910ce7a105a1 h1:gi29hTdxGXAGQvZckPZ9V8BAEfP3eK/tiZgTC5s6h1c=
 github.com/bitrise-io/go-steputils v0.0.0-20210527075147-910ce7a105a1/go.mod h1:H0iZjgsAR5NA6pnlD/zKB6AbxEsskq55pwJ9klVmP8w=
 github.com/bitrise-io/go-utils v0.0.0-20210507100250-37de47dfa6ce/go.mod h1:15EZZf02noI5nWFqXMZEoyb1CyqYRXTMz5Fyu4CWFzI=
-github.com/bitrise-io/go-utils v0.0.0-20210520073355-367fa34178f5 h1:kclxBfygfNK6kWUB+9xcsfPLBen8Us9gubhitfL/Z6c=
 github.com/bitrise-io/go-utils v0.0.0-20210520073355-367fa34178f5/go.mod h1:DRx7oFuAqk0dbKpAKCqWl0TgrowfJUb/MqYPRscxJOQ=
+github.com/bitrise-io/go-utils v0.0.0-20210713111255-08be784d45d0 h1:AMQb+o8lSsvZOV1vclhTgUF19OgpXKx6aRU/15n0TkE=
+github.com/bitrise-io/go-utils v0.0.0-20210713111255-08be784d45d0/go.mod h1:DRx7oFuAqk0dbKpAKCqWl0TgrowfJUb/MqYPRscxJOQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -151,7 +151,7 @@ func findDeployPth(deployDir, baseName, ext string) (string, error) {
 func validateAndMigrateConfig(config *Config) error {
 	if config.GradleFile != "" {
 		if exist, err := pathutil.IsPathExists(config.GradleFile); err != nil {
-			return fmt.Errorf("failed to check if GradleFile exists at: %s, error: %s", config.GradleFile, err)
+			return fmt.Errorf("failed to check if GradleFile exists at: %s: %s", config.GradleFile, err)
 		} else if !exist {
 			return fmt.Errorf("GradleFile does not exist at: %s", config.GradleFile)
 		}
@@ -202,11 +202,11 @@ func main() {
 
 	gradlewPath, err := filepath.Abs(configs.GradlewPath)
 	if err != nil {
-		failf("Can't get absolute path for gradlew file (%s), error: %s", configs.GradlewPath, err)
+		failf("Can't get absolute path for gradlew file (%s): %s", configs.GradlewPath, err)
 	}
 
 	if err := os.Chmod(gradlewPath, 0770); err != nil {
-		failf("Failed to add executable permission on gradlew file (%s), error: %s", gradlewPath, err)
+		failf("Failed to add executable permission on gradlew file (%s): %s", gradlewPath, err)
 	}
 
 	gradleStarted := time.Now()
@@ -232,7 +232,7 @@ func main() {
 			exclude: filterEmpty(strings.Split(configs.AppFileExcludeFilter, "\n")),
 		})
 	if err != nil {
-		failf("Failed to find APK or AAB files, error: %s", err)
+		failf("Failed to find APK or AAB files: %s", err)
 	}
 	if len(appFiles) == 0 {
 		log.Warnf("No file name matched app filters")
@@ -243,7 +243,7 @@ func main() {
 	for _, appFile := range appFiles {
 		fi, err := os.Lstat(appFile)
 		if err != nil {
-			failf("Failed to get file info, error: %s", err)
+			failf("Failed to get file info: %s", err)
 		}
 
 		if fi.ModTime().Before(gradleStarted) {
@@ -260,11 +260,11 @@ func main() {
 
 		deployPth, err := findDeployPth(configs.DeployDir, baseName, ext)
 		if err != nil {
-			failf("Failed to create deploy path for %s, error: %s", fileName, err)
+			failf("Failed to create deploy path for %s: %s", fileName, err)
 		}
 
 		if err := command.CopyFile(appFile, deployPth); err != nil {
-			failf("Failed to copy %s, error: %s", fileName, err)
+			failf("Failed to copy %s: %s", fileName, err)
 		}
 
 		switch strings.ToLower(ext) {
@@ -282,7 +282,7 @@ func main() {
 		if len(appFiles) != 0 {
 			lastCopiedFile := appFiles[len(appFiles)-1]
 			if err := exportEnvironmentWithEnvman(appEnv, lastCopiedFile); err != nil {
-				failf("Failed to export environment (%s), error: %s", appEnv, err)
+				failf("Failed to export environment (%s): %s", appEnv, err)
 			}
 			log.Donef("The app path is now available in the Environment Variable: $%s (value: %s)", appEnv, lastCopiedFile)
 		}
@@ -293,7 +293,7 @@ func main() {
 		if len(appFiles) != 0 {
 			appList := strings.Join(appFiles, "|")
 			if err := exportEnvironmentWithEnvman(appListEnv, appList); err != nil {
-				failf("Failed to export environment (%s), error: %s", appListEnv, err)
+				failf("Failed to export environment (%s): %s", appListEnv, err)
 			}
 			log.Donef("The app paths list is now available in the Environment Variable: $%s (value: %s)", appListEnv, appList)
 		}
@@ -305,7 +305,7 @@ func main() {
 			exclude: filterEmpty(strings.Split(configs.TestApkFileExcludeFilter, "\n")),
 		})
 	if err != nil {
-		failf("Failed to find test apk files, error: %s", err)
+		failf("Failed to find test apk files: %s", err)
 	}
 
 	if len(testApkFiles) == 0 {
@@ -316,7 +316,7 @@ func main() {
 	for _, apkFile := range testApkFiles {
 		fi, err := os.Lstat(apkFile)
 		if err != nil {
-			failf("Failed to get file info, error: %s", err)
+			failf("Failed to get file info: %s", err)
 		}
 
 		if fi.ModTime().Before(gradleStarted) {
@@ -333,18 +333,18 @@ func main() {
 
 		deployPth, err := findDeployPth(configs.DeployDir, baseName, ext)
 		if err != nil {
-			failf("Failed to create deploy path for %s, error: %s", fileName, err)
+			failf("Failed to create deploy path for %s: %s", fileName, err)
 		}
 
 		if err := command.CopyFile(apkFile, deployPth); err != nil {
-			failf("Failed to copy %s, error: %s", fileName, err)
+			failf("Failed to copy %s: %s", fileName, err)
 		}
 
 		lastCopiedTestApkFile = deployPth
 	}
 	if lastCopiedTestApkFile != "" {
 		if err := exportEnvironmentWithEnvman("BITRISE_TEST_APK_PATH", lastCopiedTestApkFile); err != nil {
-			failf("Failed to export environment (BITRISE_TEST_APK_PATH), error: %s", err)
+			failf("Failed to export environment (BITRISE_TEST_APK_PATH): %s", err)
 		}
 		log.Donef("The apk path is now available in the Environment Variable: $BITRISE_TEST_APK_PATH (value: %s)", lastCopiedTestApkFile)
 	}
@@ -357,7 +357,7 @@ func main() {
 			exclude: filterEmpty(strings.Split(configs.MappingFileExcludeFilter, "\n")),
 		})
 	if err != nil {
-		failf("Failed to find mapping files, error: %s", err)
+		failf("Failed to find mapping files: %s", err)
 	}
 
 	if len(mappingFiles) == 0 {
@@ -368,7 +368,7 @@ func main() {
 	for _, mappingFile := range mappingFiles {
 		fi, err := os.Lstat(mappingFile)
 		if err != nil {
-			failf("Failed to get file info, error: %s", err)
+			failf("Failed to get file info: %s", err)
 		}
 
 		if fi.ModTime().Before(gradleStarted) {
@@ -385,11 +385,11 @@ func main() {
 
 		deployPth, err := findDeployPth(configs.DeployDir, baseName, ext)
 		if err != nil {
-			failf("Failed to create deploy path for %s, error: %s", fileName, err)
+			failf("Failed to create deploy path for %s: %s", fileName, err)
 		}
 
 		if err := command.CopyFile(mappingFile, deployPth); err != nil {
-			failf("Failed to copy %s, error: %s", fileName, err)
+			failf("Failed to copy %s: %s", fileName, err)
 		}
 
 		lastCopiedMappingFile = deployPth
@@ -397,7 +397,7 @@ func main() {
 
 	if lastCopiedMappingFile != "" {
 		if err := exportEnvironmentWithEnvman("BITRISE_MAPPING_PATH", lastCopiedMappingFile); err != nil {
-			failf("Failed to export environment (BITRISE_MAPPING_PATH), error: %s", err)
+			failf("Failed to export environment (BITRISE_MAPPING_PATH): %s", err)
 		}
 		log.Donef("The mapping path is now available in the Environment Variable: $BITRISE_MAPPING_PATH (value: %s)", lastCopiedMappingFile)
 	}

--- a/main.go
+++ b/main.go
@@ -128,14 +128,14 @@ func findDeployPth(deployDir, baseName, ext string) (string, error) {
 	retryApkName := baseName + ext
 
 	err := retry.Times(10).Wait(1 * time.Second).Try(func(attempt uint) error {
+		requestedPath := filepath.Join(deployDir, retryApkName)
 		if attempt > 0 {
-			log.Warnf("  Retrying...")
+			log.Warnf("Trying %s instead", requestedPath)
 		}
 
 		pth, pathErr := createDeployPth(deployDir, retryApkName)
 		if pathErr != nil {
-			log.Warnf("  %d attempt failed:", attempt+1)
-			log.Printf(pathErr.Error())
+			log.Warnf("Couldn't open %s for writing: %s", requestedPath, pathErr.Error())
 		}
 
 		t := time.Now()
@@ -254,15 +254,17 @@ func main() {
 		ext := filepath.Ext(appFile)
 		baseName := filepath.Base(appFile)
 		baseName = strings.TrimSuffix(baseName, ext)
+		fileName := baseName + ext
+
+		log.Printf("Copying %s --> %s", appFile, filepath.Join(configs.DeployDir, fileName))
 
 		deployPth, err := findDeployPth(configs.DeployDir, baseName, ext)
 		if err != nil {
-			failf("Failed to create apk deploy path, error: %s", err)
+			failf("Failed to create deploy path for %s, error: %s", fileName, err)
 		}
 
-		log.Printf("copy %s to %s", appFile, deployPth)
 		if err := command.CopyFile(appFile, deployPth); err != nil {
-			failf("Failed to copy apk, error: %s", err)
+			failf("Failed to copy %s, error: %s", fileName, err)
 		}
 
 		switch strings.ToLower(ext) {
@@ -325,15 +327,17 @@ func main() {
 		ext := filepath.Ext(apkFile)
 		baseName := filepath.Base(apkFile)
 		baseName = strings.TrimSuffix(baseName, ext)
+		fileName := baseName + ext
+
+		log.Printf("Copying %s --> %s", apkFile, filepath.Join(configs.DeployDir, fileName))
 
 		deployPth, err := findDeployPth(configs.DeployDir, baseName, ext)
 		if err != nil {
-			failf("Failed to create apk deploy path, error: %s", err)
+			failf("Failed to create deploy path for %s, error: %s", fileName, err)
 		}
 
-		log.Printf("copy %s to %s", apkFile, deployPth)
 		if err := command.CopyFile(apkFile, deployPth); err != nil {
-			failf("Failed to copy apk, error: %s", err)
+			failf("Failed to copy %s, error: %s", fileName, err)
 		}
 
 		lastCopiedTestApkFile = deployPth
@@ -375,15 +379,17 @@ func main() {
 		ext := filepath.Ext(mappingFile)
 		baseName := filepath.Base(mappingFile)
 		baseName = strings.TrimSuffix(baseName, ext)
+		fileName := baseName + ext
+
+		log.Printf("Copying %s --> %s", mappingFile, filepath.Join(configs.DeployDir, fileName))
 
 		deployPth, err := findDeployPth(configs.DeployDir, baseName, ext)
 		if err != nil {
-			failf("Failed to create mapping deploy path, error: %s", err)
+			failf("Failed to create deploy path for %s, error: %s", fileName, err)
 		}
 
-		log.Printf("copy %s to %s", mappingFile, deployPth)
 		if err := command.CopyFile(mappingFile, deployPth); err != nil {
-			failf("Failed to copy mapping file, error: %s", err)
+			failf("Failed to copy %s, error: %s", fileName, err)
 		}
 
 		lastCopiedMappingFile = deployPth

--- a/step.yml
+++ b/step.yml
@@ -117,6 +117,7 @@ inputs:
   - app_file_exclude_filter: |
       *unaligned.apk
       *Test*.apk
+      */intermediates/*
     opts:
       category: Export Config
       title: "APK and AAB file exclude filter"
@@ -174,7 +175,7 @@ inputs:
         ```
         *mapping.txt
         ```
-  - mapping_file_exclude_filter:
+  - mapping_file_exclude_filter: "*/tmp/*"
     opts:
       category: Export Config
       title: "Mapping file exclude filter"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ github.com/bitrise-io/go-steputils/commandhelper
 github.com/bitrise-io/go-steputils/output
 github.com/bitrise-io/go-steputils/stepconf
 github.com/bitrise-io/go-steputils/tools
-# github.com/bitrise-io/go-utils v0.0.0-20210520073355-367fa34178f5
+# github.com/bitrise-io/go-utils v0.0.0-20210713111255-08be784d45d0
 ## explicit
 github.com/bitrise-io/go-utils/colorstring
 github.com/bitrise-io/go-utils/command


### PR DESCRIPTION
### Checklist

- [✅] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

Log messages while copying artifacts are misleading and causes confusion

Resolves: #72

### Changes

* Cleaned up log messages
* Updated dependencies

### Investigation details

Checking logs and reading reports in the #72 thread it is clear that the messaging of the step was messed up so it is hard to understand what is going on. The real reason for the stated problem is that some AGP versions or Gradle versions create intermediate or temporary `apk` , `aab` and `mapping` files that are also going to be exported without having a proper exclusion rule set-up. Related issue is #67

### Improved messaging
![image](https://user-images.githubusercontent.com/13942888/129373738-fd7ee8c2-3351-4699-93f0-29ac6ae4a010.png)