### PR TITLE
Fix optional --build-file flag in metrics

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -89,9 +89,12 @@ func (c *Collector) SendMetrics() error {
 func (c *Collector) runGradleTask(initScriptPath string) error {
 	args := []string{
 		"producer",
-		"--build-file", c.buildFilePath,
 		"--init-script", initScriptPath,
 	}
+	if c.buildFilePath != "" {
+		args = append(args, "--build-file", c.buildFilePath)
+	}
+
 	opts := command.Opts{
 		Stdout: os.Stdout,
 		Stderr: os.Stderr,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

Follow-up to #102.

The build file step input is optional, so the metrics code should treat it optional as well.

### Changes

Only pass the `--build-file` flag to Gradle if it has a value

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
