### PR TITLE
Load plugin from Maven Central

### DIFF
--- a/metrics/init.gradle.gotemplate
+++ b/metrics/init.gradle.gotemplate
@@ -1,9 +1,5 @@
 initscript {
    repositories {
-      // TODO: remove this once we publish 1.0.0
-      maven {
-         url 'https://s01.oss.sonatype.org/content/repositories/snapshots/'
-      }
       maven {
          url 'https://plugins.gradle.org/m2/'
       }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -18,7 +18,7 @@ const defaultPort = 443
 // Sync the major version of this step and the plugin.
 // Use the latest 1.x version of the plugin, so we don't have to update this definition after every plugin release.
 // But don't forget to update this to `2.+` if the library reaches version 2.0!
-const defaultPluginVersion = "main-SNAPSHOT" // TODO: change to 1.+
+const defaultPluginVersion = "0.+" // TODO: change to 1.+
 
 type Collector struct {
 	envRepo       env.Repository


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

The Gradle plugin is now published to Maven Central as v0.1.0. This means we can remove the staging repo from the init script.

### Changes

- Remove staging repo from Gradle script
- Use `0.+` as the version constraint until we set 1.0.0

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
