### PR TITLE
Enable metrics based on env

### DIFF
--- a/main.go
+++ b/main.go
@@ -224,7 +224,9 @@ func main() {
 	pathProvider := v2pathutil.NewPathProvider()
 	logger := v2log.NewLogger()
 	collector := metrics.NewCollector(envRepo, cmdFactory, pathProvider, logger, gradlewPath, configs.GradleFile)
-	if configs.CollectMetrics && collector.CanBeEnabled(configs.GradleOptions) {
+	collectMetrics := collector.CanBeEnabled(configs.GradleOptions) &&
+		(configs.CollectMetrics || envRepo.Get("BITRISEIO_GRADLE_COLLECT_METRICS") == "true")
+	if collectMetrics {
 		err = collector.SetupMetricsCollection()
 		if err == nil {
 			configs.GradleOptions = collector.UpdateGradleFlagsWithInitScript(configs.GradleOptions)
@@ -428,7 +430,7 @@ func main() {
 		log.Donef("The mapping path is now available in the Environment Variable: $BITRISE_MAPPING_PATH (value: %s)", lastCopiedMappingFile)
 	}
 
-	if configs.CollectMetrics {
+	if collectMetrics {
 		log.Printf("\n")
 		log.Infof("Sending collected metrics...")
 		err := collector.SendMetrics()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

https://github.com/bitrise-steplib/bitrise-step-activate-gradle-remote-cache/pull/17

### Changes

Next to the dedicated input switch, also enable metrics collection if a previous step exports a special step output to do so.

### Investigation details

Changing the default value of the input to `collect_metrics: $BITRISEIO_GRADLE_COLLECT_METRICS` would normally work, except for boolean step inputs where the possible values are constrained to `yes` and `no`. An undefined env var would fail step input validation.

### Decisions

<!-- Please list decisions that were made for this change. -->
