### PR TITLE
Fix artifact matching and tests

### DIFF
--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -106,6 +106,197 @@ func Test_findArtifacts(t *testing.T) {
 			want:      []string{"a/test.apk", "b/test.aab"},
 			wantErr:   false,
 		},
+		{
+			name: "Empty include patterns",
+			patterns: filePatterns{
+				include: []string{},
+				exclude: []string{},
+			},
+			filePaths: []string{"test.apk", "test.aab"},
+			want:      nil,
+			wantErr:   false,
+		},
+		{
+			name: "No files match include pattern",
+			patterns: filePatterns{
+				include: []string{"*.jar"},
+				exclude: []string{},
+			},
+			filePaths: []string{"test.apk", "test.aab"},
+			want:      nil,
+			wantErr:   false,
+		},
+		{
+			name: "All files excluded",
+			patterns: filePatterns{
+				include: []string{"*.apk"},
+				exclude: []string{"*.apk"},
+			},
+			filePaths: []string{"test.apk", "other.apk"},
+			want:      nil,
+			wantErr:   false,
+		},
+		{
+			name: "Files with spaces and special characters",
+			patterns: filePatterns{
+				include: []string{"*.apk"},
+				exclude: []string{},
+			},
+			filePaths: []string{"app release-v1.0.apk", "test (debug).apk", "café-release.apk"},
+			want:      []string{"app release-v1.0.apk", "test (debug).apk", "café-release.apk"},
+			wantErr:   false,
+		},
+		{
+			name: "Deep nested directories",
+			patterns: filePatterns{
+				include: []string{"*.apk", "**/*.apk"},
+				exclude: []string{},
+			},
+			filePaths: []string{"a/b/c/d/e/f/deep.apk", "shallow.apk"},
+			want:      []string{"a/b/c/d/e/f/deep.apk", "shallow.apk"},
+			wantErr:   false,
+		},
+		{
+			name: "Mixed file types with multiple patterns",
+			patterns: filePatterns{
+				include: []string{"*.apk", "*.aab", "*.jar"},
+				exclude: []string{"*test*"},
+			},
+			filePaths: []string{"app.apk", "app.aab", "lib.jar", "test.apk", "test.aab", "readme.txt"},
+			want:      []string{"app.apk", "app.aab", "lib.jar"},
+			wantErr:   false,
+		},
+		{
+			name: "Overlapping include and exclude patterns",
+			patterns: filePatterns{
+				include: []string{"*release*", "*debug*"},
+				exclude: []string{"*unaligned*"},
+			},
+			filePaths: []string{"app-release.apk", "app-debug.apk", "app-release-unaligned.apk", "app-debug-unaligned.apk", "other.apk"},
+			want:      []string{"app-release.apk", "app-debug.apk"},
+			wantErr:   false,
+		},
+		{
+			name: "Complex directory patterns",
+			patterns: filePatterns{
+				include: []string{"build/outputs/**/*.apk", "app/build/**/*.aab"},
+				exclude: []string{"**/intermediates/**/*", "**/tmp/**/*"},
+			},
+			filePaths: []string{
+				"build/outputs/apk/debug/app.apk",
+				"build/outputs/apk/release/app.apk", 
+				"app/build/outputs/bundle/release/app.aab",
+				"build/intermediates/apk/debug/temp.apk",
+				"build/tmp/cache/temp.apk",
+				"other/app.apk",
+			},
+			want: []string{"build/outputs/apk/debug/app.apk", "build/outputs/apk/release/app.apk", "app/build/outputs/bundle/release/app.aab"},
+			wantErr: false,
+		},
+		{
+			name: "Empty exclude patterns with empty strings",
+			patterns: filePatterns{
+				include: []string{"*.apk"},
+				exclude: []string{"", "", ""},
+			},
+			filePaths: []string{"test.apk", "other.apk"},
+			want:      []string{"test.apk", "other.apk"},
+			wantErr:   false,
+		},
+		{
+			name: "Default APK/AAB include patterns from step.yml",
+			patterns: filePatterns{
+				include: []string{"*.apk", "*.aab"},
+				exclude: []string{},
+			},
+			filePaths: []string{"app-release.apk", "app-debug.apk", "app.aab", "lib.jar", "README.md"},
+			want:      []string{"app-release.apk", "app-debug.apk", "app.aab"},
+			wantErr:   false,
+		},
+		{
+			name: "Default APK/AAB exclude patterns from step.yml",
+			patterns: filePatterns{
+				include: []string{"*.apk", "*.aab"},
+				exclude: []string{"*unaligned.apk", "*Test*.apk", "*/intermediates/*"},
+			},
+			filePaths: []string{
+				"app-release.apk",
+				"app-debug-unaligned.apk",
+				"app-androidTest.apk",
+				"build/intermediates/apk/debug/temp.apk",
+				"app.aab",
+			},
+			want: []string{"app-release.apk", "app.aab"},
+			wantErr: false,
+		},
+		{
+			name: "Default test APK include pattern from step.yml",
+			patterns: filePatterns{
+				include: []string{"*Test*.apk"},
+				exclude: []string{},
+			},
+			filePaths: []string{
+				"app-release.apk",
+				"app-androidTest.apk", 
+				"app-debugAndroidTest.apk",
+				"Test-runner.apk",
+				"app.aab",
+			},
+			want: []string{"app-androidTest.apk", "app-debugAndroidTest.apk", "Test-runner.apk"},
+			wantErr: false,
+		},
+		{
+			name: "Default mapping file include pattern from step.yml",
+			patterns: filePatterns{
+				include: []string{"*/mapping.txt"},
+				exclude: []string{},
+			},
+			filePaths: []string{
+				"app/build/outputs/mapping/release/mapping.txt",
+				"build/outputs/mapping/debug/mapping.txt",
+				"mapping.txt",
+				"other.txt",
+				"app.apk",
+			},
+			want: []string{"app/build/outputs/mapping/release/mapping.txt", "build/outputs/mapping/debug/mapping.txt"},
+			wantErr: false,
+		},
+		{
+			name: "Default mapping file exclude pattern from step.yml", 
+			patterns: filePatterns{
+				include: []string{"*/mapping.txt"},
+				exclude: []string{"*/tmp/*"},
+			},
+			filePaths: []string{
+				"app/build/outputs/mapping/release/mapping.txt", 
+				"build/tmp/mapping/mapping.txt",
+				"some/tmp/cache/mapping.txt",
+			},
+			want: []string{"app/build/outputs/mapping/release/mapping.txt"},
+			wantErr: false,
+		},
+		{
+			name: "Real-world Android build structure with defaults",
+			patterns: filePatterns{
+				include: []string{"*.apk", "*.aab"},
+				exclude: []string{"*unaligned.apk", "*Test*.apk", "*/intermediates/*"},
+			},
+			filePaths: []string{
+				"app/build/outputs/apk/debug/app-debug.apk",
+				"app/build/outputs/apk/release/app-release.apk", 
+				"app/build/outputs/apk/release/app-release-unaligned.apk",
+				"app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk",
+				"app/build/outputs/bundle/release/app-release.aab",
+				"app/build/intermediates/apk_ide_redirect/debug/redirect.apk",
+				"build/intermediates/merged_manifests/debug/temp.apk",
+			},
+			want: []string{
+				"app/build/outputs/apk/debug/app-debug.apk",
+				"app/build/outputs/apk/release/app-release.apk",
+				"app/build/outputs/bundle/release/app-release.aab",
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

#112 introduced a regression in artifact pattern matching by changing the root of file search from `.` to the absolute path of `.`.

I discovered more issues during investigation of the above:

#### Issue 1: Glob patterns applied to absolute paths
The `findArtifacts` function was applying glob patterns directly to absolute file paths returned by `filepath.Walk()`. This worked previously because `filepath.Walk()` was initialized with `.` as the root of the search. After #112 (absolute search dir → absolute paths in `WalkFunc`), it should have been caught by a failing test, but:

#### Issue 2: flawed tests and accidental maches

Patterns like `*Test*.apk` matched files in temp directories containing "Test" in their path, for example, `/tmp/Test123/a/somethingelse.apk`, instead of matching a `Test.apk` in an arbitrary subdirectory. This is why #112 passed CI checks and we let it merge.


### Changes

1. Convert absolute paths to relative paths using `filepath.Rel(searchDir, path)` before pattern matching

2. Modernize test setup
- Replaced deprecated `ioutil.TempDir()` with `t.TempDir()`
- Fixed one test case with incorrect pattern structure (`*/a/*.apk` → `a/*.apk`). I think this test was coded to align with the accidentally flawed implementation and it shouldn't have passed in the first place.


